### PR TITLE
Not able to build ConferenceApp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.antmedia</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.3.2-SNAPSHOT</version>
+		<version>2.3.2</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.antmedia.conference</groupId>


### PR DESCRIPTION
Blog Reference:
https://antmedia.io/how-to-create-a-conference-solution-ant-media-server/

I tried to build the ConferenceApp project with following command (as described in blog above)

           mvn clean install -DskipTests -Dgpg.skip=true

It thown dependency error.

Making the changes in pom.xml file resolves the error and project builds successfully.